### PR TITLE
Fix php warnings

### DIFF
--- a/src/DcaCallbacks.php
+++ b/src/DcaCallbacks.php
@@ -44,7 +44,7 @@ class DcaCallbacks extends \Contao\Backend
                         continue;
                     }
                     \Contao\Controller::loadDataContainer($table);
-                    if (is_array($GLOBALS['TL_DCA'][$table]['fields']) && count($GLOBALS['TL_DCA'][$table]['fields']) > 0) foreach ($GLOBALS['TL_DCA'][$table]['fields'] as $field => $column) {
+                    if (array_key_exists($table, $GLOBALS['TL_DCA']) && is_array($GLOBALS['TL_DCA'][$table]['fields']) && count($GLOBALS['TL_DCA'][$table]['fields']) > 0) foreach ($GLOBALS['TL_DCA'][$table]['fields'] as $field => $column) {
                         if (!isset($column['sql']) || !isset($column['inputType'])) {
                             continue;
                         }

--- a/src/DcaCallbacks.php
+++ b/src/DcaCallbacks.php
@@ -44,7 +44,7 @@ class DcaCallbacks extends \Contao\Backend
                         continue;
                     }
                     \Contao\Controller::loadDataContainer($table);
-                    if (array_key_exists($table, $GLOBALS['TL_DCA']) && is_array($GLOBALS['TL_DCA'][$table]['fields']) && count($GLOBALS['TL_DCA'][$table]['fields']) > 0) foreach ($GLOBALS['TL_DCA'][$table]['fields'] as $field => $column) {
+                    if (array_key_exists($table, $GLOBALS['TL_DCA']) && array_key_exists('fields', $GLOBALS['TL_DCA'][$table]) && count($GLOBALS['TL_DCA'][$table]['fields']) > 0) foreach ($GLOBALS['TL_DCA'][$table]['fields'] as $field => $column) {
                         if (!isset($column['sql']) || !isset($column['inputType'])) {
                             continue;
                         }
@@ -165,7 +165,7 @@ class DcaCallbacks extends \Contao\Backend
                                                         case 'image':
                                                         case 'picture':
                                                         case 'file':
-															$objFiles = null;
+                                                            $objFiles = null;
                                                             if (\Contao\Validator::isUuid($value)) {
                                                                 // Handle UUIDs
                                                                 $objFiles = \Contao\FilesModel::findByUuid($value);

--- a/src/DcaCallbacks.php
+++ b/src/DcaCallbacks.php
@@ -165,6 +165,7 @@ class DcaCallbacks extends \Contao\Backend
                                                         case 'image':
                                                         case 'picture':
                                                         case 'file':
+															$objFiles = null;
                                                             if (\Contao\Validator::isUuid($value)) {
                                                                 // Handle UUIDs
                                                                 $objFiles = \Contao\FilesModel::findByUuid($value);


### PR DESCRIPTION
This PR fixes two warnings, one warning if a table is not in $GLOBALS['TL_DCA'] (for example rememberme_token or tl_crawl_queue) and one caused by a variable that might be undefined.